### PR TITLE
bug fix qim threads

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 		<!-- <matsim.version>12.0-SNAPSHOT</matsim.version>  -->
 
 	  <!--weekly "release":-->
-	  <matsim.version>13.0-2020w28-SNAPSHOT</matsim.version>
+	  <matsim.version>13.0-2020w30-SNAPSHOT</matsim.version>
 	</properties>
 
 	<repositories>

--- a/src/main/java/org/matsim/drtSpeedUp/DrtSpeedUp.java
+++ b/src/main/java/org/matsim/drtSpeedUp/DrtSpeedUp.java
@@ -108,17 +108,19 @@ final class DrtSpeedUp implements PersonDepartureEventHandler, PersonEntersVehic
 	
 	private final String mode;
 
-	private int originalNumberOfQsimThreads;
+	private final int originalNumberOfQsimThreads;
 
 	private FleetSpecification fleetSpecification;
 
 	public DrtSpeedUp(String mode,
 			DrtSpeedUpConfigGroup drtSpeedUpConfigGroup,
+			int numberOfQsimThreads,
 			EventsManager events,
 			Scenario scenario,
 			FleetSpecification fleetSpecification) {	
 		this.mode = mode;
 		this.drtSpeedUpConfigGroup = drtSpeedUpConfigGroup;
+		this.originalNumberOfQsimThreads = numberOfQsimThreads;
 		this.events = events;
 		this.scenario = scenario;
 		this.fleetSpecification = fleetSpecification;
@@ -142,7 +144,6 @@ final class DrtSpeedUp implements PersonDepartureEventHandler, PersonEntersVehic
 	
 	@Override
 	public void notifyStartup(StartupEvent event) {
-		originalNumberOfQsimThreads = this.scenario.getConfig().qsim().getNumberOfThreads();
 		log.info("initial number of qsim threads: " + originalNumberOfQsimThreads);
 		
 		for (DrtFareConfigGroup drtFareCfg : DrtFaresConfigGroup.get(scenario.getConfig()).getDrtFareConfigGroups()) {
@@ -184,7 +185,6 @@ final class DrtSpeedUp implements PersonDepartureEventHandler, PersonEntersVehic
 		}
 		
 		if (teleportDrtUsers) {
-			originalNumberOfQsimThreads = this.scenario.getConfig().qsim().getNumberOfThreads();
 			this.scenario.getConfig().qsim().setNumberOfThreads(this.drtSpeedUpConfigGroup.getNumberOfThreadsForMobsimDuringSpeedUp());
 			log.info("Teleporting all drt modes. Setting number of qsim threads from previously " +
 					originalNumberOfQsimThreads + " to " +

--- a/src/main/java/org/matsim/drtSpeedUp/DrtSpeedUpModule.java
+++ b/src/main/java/org/matsim/drtSpeedUp/DrtSpeedUpModule.java
@@ -33,10 +33,12 @@ import com.google.inject.Inject;
 class DrtSpeedUpModule extends AbstractDvrpModeModule {
 	
 	private final String mode;
+	private final int numberOfQsimThreads;
 	
-	protected DrtSpeedUpModule(String mode) {
+	protected DrtSpeedUpModule(String mode, int numberOfQsimThreads) {
 		super(mode);
 		this.mode = mode;
+		this.numberOfQsimThreads = numberOfQsimThreads;
 	}
 	
 	@Inject
@@ -47,6 +49,7 @@ class DrtSpeedUpModule extends AbstractDvrpModeModule {
 		bindModal(DrtSpeedUp.class).toProvider(modalProvider(
 				getter -> new DrtSpeedUp(mode,
 						drtSpeedUpConfigGroup,
+						numberOfQsimThreads,
 						getter.get(EventsManager.class),
 						getter.get(Scenario.class),
 						getter.getModal(FleetSpecification.class)))).asEagerSingleton();

--- a/src/main/java/org/matsim/drtSpeedUp/MultiModeDrtSpeedUpModule.java
+++ b/src/main/java/org/matsim/drtSpeedUp/MultiModeDrtSpeedUpModule.java
@@ -25,6 +25,7 @@ import org.matsim.contrib.drt.run.MultiModeDrtConfigGroup;
 import org.matsim.core.config.Config;
 import org.matsim.core.config.ConfigUtils;
 import org.matsim.core.config.groups.PlanCalcScoreConfigGroup.ModeParams;
+import org.matsim.core.config.groups.QSimConfigGroup;
 import org.matsim.core.controler.AbstractModule;
 
 import com.google.inject.Inject;
@@ -40,10 +41,13 @@ public class MultiModeDrtSpeedUpModule extends AbstractModule {
 	@Inject
 	private DrtSpeedUpConfigGroup drtSpeedUpConfigGroup;
 
+	@Inject
+	private QSimConfigGroup qSimConfigGroup;
+
 	@Override
 	public void install() {	
 		for (String mode : drtSpeedUpConfigGroup.getModes().split(",")) {
-			install(new DrtSpeedUpModule(mode));
+			install(new DrtSpeedUpModule(mode, qSimConfigGroup.getNumberOfThreads()));
 		}
 	}
 	

--- a/src/test/java/org/matsim/drtSpeedUp/DrtSpeedUpTest.java
+++ b/src/test/java/org/matsim/drtSpeedUp/DrtSpeedUpTest.java
@@ -1,11 +1,31 @@
 package org.matsim.drtSpeedUp;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
+import org.matsim.api.core.v01.Scenario;
+import org.matsim.contrib.av.robotaxi.fares.drt.DrtFareModule;
+import org.matsim.contrib.av.robotaxi.fares.drt.DrtFaresConfigGroup;
+import org.matsim.contrib.drt.routing.DrtRoute;
+import org.matsim.contrib.drt.routing.DrtRouteFactory;
+import org.matsim.contrib.drt.run.DrtConfigs;
+import org.matsim.contrib.drt.run.MultiModeDrtConfigGroup;
+import org.matsim.contrib.drt.run.MultiModeDrtModule;
+import org.matsim.contrib.dvrp.run.DvrpConfigGroup;
+import org.matsim.contrib.dvrp.run.DvrpModule;
+import org.matsim.contrib.dvrp.run.DvrpQSimComponents;
+import org.matsim.core.config.Config;
+import org.matsim.core.config.ConfigUtils;
+import org.matsim.core.controler.Controler;
+import org.matsim.core.controler.events.BeforeMobsimEvent;
+import org.matsim.core.controler.listener.BeforeMobsimListener;
+import org.matsim.core.population.routes.RouteFactories;
+import org.matsim.core.scenario.ScenarioUtils;
 import org.matsim.testcases.MatsimTestUtils;
 
 /**
@@ -27,6 +47,50 @@ public class DrtSpeedUpTest {
 		Assert.assertEquals("Wrong moving average.", 29./3., DrtSpeedUp.computeMovingAverage(3, list), MatsimTestUtils.EPSILON);
 		Assert.assertEquals("Wrong moving average.", 27./2., DrtSpeedUp.computeMovingAverage(2, list), MatsimTestUtils.EPSILON);
 		Assert.assertEquals("Wrong moving average.", 29./3., DrtSpeedUp.computeMovingAverage(4, list), MatsimTestUtils.EPSILON);
+	}
+
+	@Test
+	public final void testQsimThreads() {
+		Config config = ConfigUtils.loadConfig("scenarios/equil/config-with-drt.xml", new MultiModeDrtConfigGroup(), new DvrpConfigGroup(), new DrtFaresConfigGroup(), new DrtSpeedUpConfigGroup());
+		// remove demand to speed up this test
+		config.plans().setInputFile(null);
+		config.controler().setRunId("test2");
+		config.controler().setOutputDirectory(utils.getOutputDirectory());
+		config.controler().setLastIteration(2);
+		config.qsim().setNumberOfThreads(4);
+		DrtSpeedUpConfigGroup speedUpConfig = ConfigUtils.addOrGetModule(config, DrtSpeedUpConfigGroup.class);
+		speedUpConfig.setIntervalDetailedIteration(2);
+		speedUpConfig.setNumberOfThreadsForMobsimDuringSpeedUp(8);
+
+		DrtConfigs.adjustMultiModeDrtConfig(MultiModeDrtConfigGroup.get(config), config.planCalcScore(), config.plansCalcRoute());
+		MultiModeDrtSpeedUpModule.addTeleportedDrtMode(config);
+
+		Scenario scenario = ScenarioUtils.loadScenario(config);
+
+		RouteFactories routeFactories = scenario.getPopulation().getFactory().getRouteFactories();
+		routeFactories.setRouteFactory(DrtRoute.class, new DrtRouteFactory());
+
+		Controler controler = new Controler(scenario);
+		controler.addOverridingModule(new MultiModeDrtModule());
+		controler.addOverridingModule(new DvrpModule());
+		controler.configureQSimComponents(DvrpQSimComponents.activateAllModes(MultiModeDrtConfigGroup.get(controler.getConfig())));
+		controler.addOverridingModule(new DrtFareModule());
+
+		controler.addOverridingModule(new MultiModeDrtSpeedUpModule());
+
+		Map<Integer, Integer> iteration2numQsimThreads = new HashMap<>();
+		controler.addControlerListener(new BeforeMobsimListener() {
+			@Override
+			public void notifyBeforeMobsim(BeforeMobsimEvent beforeMobsimEvent) {
+				iteration2numQsimThreads.put(beforeMobsimEvent.getIteration(), config.qsim().getNumberOfThreads());
+			}
+		});
+
+		controler.run();
+
+		Assert.assertEquals("Wrong number of qsim threads.", 4, iteration2numQsimThreads.get(0).intValue());
+		Assert.assertEquals("Wrong number of qsim threads.", 8, iteration2numQsimThreads.get(1).intValue());
+		Assert.assertEquals("Wrong number of qsim threads.", 4, iteration2numQsimThreads.get(2).intValue());
 	}
 
 }


### PR DESCRIPTION
previously number of qsim thread was not set back to the original value from config in the real drt iterations (since ca. start of August number of qsim threads was read from config instead of always assuming 1)